### PR TITLE
Configure nginx proxy and simplify API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # frontend of the web-app to order taxi - React
 
+## Nginx configuration
+
+Use the provided `nginx.conf` to serve the production build and proxy API
+requests to the backend running on `localhost:8082`. With this configuration,
+the frontend can call endpoints using relative paths such as `/api/users`.
+
+```
+nginx -c /path/to/nginx.conf
+```
+
+The `/api/` location is forwarded to `http://localhost:8082/api/`, so the code no
+longer needs to include the full `http://localhost:8082/api` prefix.
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://localhost:8082/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/src/pages/AccountSettings.js
+++ b/src/pages/AccountSettings.js
@@ -21,7 +21,7 @@ function AccountSettings() {
   const [useDefaultAddress, setUseDefaultAddress] = useState(false);
 
   useEffect(() => {
-    axios.get(`http://localhost:8082/api/users/profile/${id}`)
+    axios.get(`/api/users/profile/${id}`)
       .then(res => {
         setUser(res.data);
       })
@@ -33,7 +33,7 @@ function AccountSettings() {
   };
 
   const toggleVisibility = () => {
-    axios.put(`http://localhost:8082/api/users/toggle-visibility/${id}`)
+    axios.put(`/api/users/toggle-visibility/${id}`)
       .then(res => {
         alert(res.data);
         setUser(prev => ({ ...prev, visible: !prev.visible }));
@@ -42,12 +42,12 @@ function AccountSettings() {
   };
 
   const handleSave = () => {
-    axios.put(`http://localhost:8082/api/users/update/${id}`, user)
+    axios.put(`/api/users/update/${id}`, user)
       .then(res => alert(res.data))
       .catch(err => alert("Erreur de sauvegarde : " + err.message));
 
     if (useDefaultAddress) {
-      axios.put(`http://localhost:8082/api/users/set-default-address/${id}`, {
+      axios.put(`/api/users/set-default-address/${id}`, {
         address: user.address
       }).then(res => console.log("Adresse par défaut mise à jour"))
         .catch(err => console.error(err));
@@ -56,7 +56,7 @@ function AccountSettings() {
 
   const handleDelete = () => {
     if (window.confirm("Êtes-vous sûr de vouloir supprimer ce compte ?")) {
-      axios.delete(`http://localhost:8082/api/users/delete/${id}`)
+      axios.delete(`/api/users/delete/${id}`)
         .then(res => {
           alert(res.data);
           navigate("/");
@@ -66,7 +66,7 @@ function AccountSettings() {
   };
 
   const handleReset = () => {
-    axios.get(`http://localhost:8082/api/users/reset-form/${id}`)
+    axios.get(`/api/users/reset-form/${id}`)
       .then(res => setUser(res.data))
       .catch(err => alert("Erreur de réinitialisation : " + err.message));
   };
@@ -83,7 +83,7 @@ function AccountSettings() {
     const formData = new FormData();
     formData.append("photo", selectedPhoto);
 
-    axios.put(`http://localhost:8082/api/users/update-photo/${id}`, formData, {
+    axios.put(`/api/users/update-photo/${id}`, formData, {
       headers: { "Content-Type": "multipart/form-data" }
     })
       .then(res => {

--- a/src/pages/DriverDashboard.js
+++ b/src/pages/DriverDashboard.js
@@ -22,7 +22,7 @@ const DriverDashboard = () => {
         longitude: coords?.lng || null
       };
 
-      await axios.put(`http://localhost:8082/api/drivers/en-ligne/${id}`, body);
+      await axios.put(`/api/drivers/en-ligne/${id}`, body);
     } catch (err) {
       console.error("Erreur backend :", err);
       alert("Erreur de mise à jour du statut en ligne.");

--- a/src/pages/ForgotPassword.js
+++ b/src/pages/ForgotPassword.js
@@ -15,7 +15,7 @@ function ForgotPassword() {
     setError('');
 
     try {
-      const response = await axios.post('http://localhost:8082/api/auth/forgot-password', { email }, {
+      const response = await axios.post('/api/auth/forgot-password', { email }, {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -27,8 +27,8 @@ function Login() {
 
     const endpoint =
       selectedRole === "driver"
-        ? "http://localhost:8082/api/drivers/login"
-        : "http://localhost:8082/api/auth/login";
+        ? "/api/drivers/login"
+        : "/api/auth/login";
 
     try {
       const res = await axios.post(endpoint, formData);

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -53,8 +53,8 @@ const Register = () => {
 
     const endpoint =
       selectedRole === "driver"
-        ? "http://localhost:8082/api/drivers/register"
-        : "http://localhost:8082/api/auth/register";
+        ? "/api/drivers/register"
+        : "/api/auth/register";
 
     try {
       await axios.post(endpoint, user);

--- a/src/pages/TaxiDashboard.js
+++ b/src/pages/TaxiDashboard.js
@@ -51,7 +51,7 @@ const TaxiDashboard = () => {
 
     const fetchCourses = async () => {
       try {
-        const res = await axios.get(`http://localhost:8082/api/courses/for-driver/${id}`, {
+        const res = await axios.get(`/api/courses/for-driver/${id}`, {
           params: {
             latitude: position.lat,
             longitude: position.lng,
@@ -87,7 +87,7 @@ const TaxiDashboard = () => {
 
   const confirmAccept = async () => {
     try {
-      await axios.put(`http://localhost:8082/api/courses/accept/${acceptOrder.id}`, null, {
+      await axios.put(`/api/courses/accept/${acceptOrder.id}`, null, {
         params: { driverId: id }
       });
 

--- a/src/pages/UpdatePassword.js
+++ b/src/pages/UpdatePassword.js
@@ -32,7 +32,7 @@ function UpdatePassword() {
     }
 
     try {
-      const response = await axios.post('http://localhost:8082/api/auth/update-password', {
+      const response = await axios.post('/api/auth/update-password', {
         token,
         newPassword
       }, {

--- a/src/pages/User/InnerCourseRequestPage.js
+++ b/src/pages/User/InnerCourseRequestPage.js
@@ -31,7 +31,7 @@ const InnerCourseRequestPage = ({ userPosition, userId }) => {
   useEffect(() => {
     const interval = setInterval(async () => {
       try {
-        const res = await axios.get(`http://localhost:8082/api/courses/status/${userId}`);
+        const res = await axios.get(`/api/courses/status/${userId}`);
         if (res.data && res.data.status) {
           setCourseData(prev =>
             !prev || prev.id !== res.data.id || prev.status !== res.data.status
@@ -58,7 +58,7 @@ const InnerCourseRequestPage = ({ userPosition, userId }) => {
       const results = await getGeocode({ address });
       const { lat, lng } = await getLatLng(results[0]);
 
-      const res = await axios.post('http://localhost:8082/api/courses/request', {
+      const res = await axios.post('/api/courses/request', {
         userId,
         depart: {
           latitude: userPosition.lat,

--- a/src/pages/UserTransactionsList.js
+++ b/src/pages/UserTransactionsList.js
@@ -7,7 +7,7 @@ const UserTransactionsList = ({ userId }) => {
   const [transactions, setTransactions] = useState([]);
 
   useEffect(() => {
-    axios.get(`http://localhost:8082/api/transactions/user/${userId}`)
+    axios.get(`/api/transactions/user/${userId}`)
       .then(res => setTransactions(res.data))
       .catch(err => console.error("Erreur : ", err));
   }, [userId]);

--- a/src/pages/ValidateToken.js
+++ b/src/pages/ValidateToken.js
@@ -13,7 +13,7 @@ function ValidateToken() {
     setError('');
 
     try {
-      const response = await axios.post('http://localhost:8082/api/auth/validate-token', { token }, {
+      const response = await axios.post('/api/auth/validate-token', { token }, {
         headers: { 'Content-Type': 'application/json' },
       });
 


### PR DESCRIPTION
## Summary
- add nginx configuration to proxy `/api` to backend
- document nginx setup in `README.md`
- update axios calls to use relative `/api` paths

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643e10b06c832b94ee36257386ebeb